### PR TITLE
feat: bundle PreToolUse hook to auto-redirect Read on data-heavy files

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,4 +1,16 @@
 {
-  "description": "Project hooks",
-  "hooks": {}
+  "description": "Context-mode PreToolUse guard — blocks Read on data-heavy files (.log, .csv, .xml, .sql, .json >100KB) to conserve context window",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/log-read-guard.cjs"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/hooks/log-read-guard.cjs
+++ b/hooks/log-read-guard.cjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse Guard: Block raw data dumps via Read
+ *
+ * Matcher: Read
+ * Trigger: PreToolUse
+ * Latency: ~2ms (single JSON parse + string check)
+ *
+ * Blocks Read on: .log, .csv, .xml, .sql, .json >100KB
+ *
+ * Non-zero exit blocks the tool call.
+ * stdout JSON is shown to Claude as guidance.
+ */
+
+'use strict';
+
+try {
+  const fs = require('fs');
+
+  // Read JSON from stdin (hook input format)
+  const raw = fs.readFileSync('/dev/stdin', 'utf8').trim();
+  if (!raw) process.exit(0);
+
+  const input = JSON.parse(raw);
+  const filePath = input.tool_input?.file_path ?? '';
+
+  // Extensions to block
+  const BLOCKED_EXTENSIONS = ['.log', '.csv', '.xml', '.sql'];
+  const ext = filePath.toLowerCase();
+
+  const isBlockedExt = BLOCKED_EXTENSIONS.some(e => ext.endsWith(e));
+  const isLargeJson = ext.endsWith('.json') && (() => {
+    try {
+      const stat = fs.statSync(filePath);
+      return stat.size > 100 * 1024; // 100KB
+    } catch { return false; }
+  })();
+
+  if (!isBlockedExt && !isLargeJson) process.exit(0);
+
+  const fileExt = filePath.split('.').pop().toUpperCase();
+  const sizeHint = isLargeJson ? ' (large JSON)' : '';
+
+  console.error(`[log-read-guard] Blocked Read on ${fileExt}${sizeHint} file: ${filePath}`);
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason:
+        `Do NOT use Read on ${fileExt}${sizeHint} files — raw ${fileExt} output floods context window.\n` +
+        `Use execute instead:\n` +
+        `\`\`\`\nexecute({\n` +
+        `  language: "javascript",\n` +
+        `  code: \`\n` +
+        `const fs = require('fs');\n` +
+        `const data = JSON.parse(fs.readFileSync('${filePath}', 'utf8'));\n` +
+        `// Process, filter, aggregate — console.log() only the answer\n` +
+        `\`\n` +
+        `})\n\`\`\`\n` +
+        `Or use batch_execute for shell commands.\n` +
+        `Read tool is ONLY for files you intend to Edit.`
+    }
+  }));
+  process.exit(0); // Exit 0 with JSON = deny
+} catch {
+  // Any error — allow the tool call
+  process.exit(0);
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "build",
+    "hooks",
     ".claude-plugin",
     ".mcp.json",
     "README.md",


### PR DESCRIPTION
## Summary
- Bundles `log-read-guard.cjs` as a plugin hook — users get automatic context window protection on install
- Blocks `Read` on `.log`, `.csv`, `.xml`, `.sql`, and `.json >100KB` files, redirecting to `execute`/`batch_execute` instead
- Uses `.cjs` extension to ensure CommonJS parsing (parent `package.json` has `"type": "module"`)

## Changes
- `hooks/log-read-guard.cjs` — PreToolUse guard script (blocks data-heavy file reads)
- `hooks/hooks.json` — declares hook with `${CLAUDE_PLUGIN_ROOT}` path
- `package.json` — adds `"hooks"` to `files` array for npm publishing

## Test plan
- [x] Hook blocks `.log` files with proper `permissionDecision: "deny"` JSON
- [x] Hook blocks `.csv`, `.xml`, `.sql` files
- [x] Hook allows `.txt` and other non-blocked extensions
- [x] `.cjs` extension works correctly inside `"type": "module"` package
- [ ] Verify `claude plugin add` installs hook automatically