### PR TITLE
feat: block WebSearch — redirect to execute with curl/ddg

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -12,7 +12,7 @@
         ]
       },
       {
-        "matcher": "WebFetch|webReader",
+        "matcher": "WebFetch|webReader|WebSearch",
         "hooks": [
           {
             "type": "command",

--- a/hooks/web-fetch-guard.cjs
+++ b/hooks/web-fetch-guard.cjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 /**
- * PreToolUse Guard: Block WebFetch/webReader raw HTML dumps
+ * PreToolUse Guard: Block WebFetch/webReader/WebSearch
  *
- * Matcher: WebFetch|webReader
+ * Matcher: WebFetch|webReader|WebSearch
  * Trigger: PreToolUse
  * Latency: ~1ms (single JSON parse + string check)
  *
- * Blocks WebFetch and webReader (MCP) tool calls.
- * Redirects to fetch_and_index which indexes to FTS5.
+ * Blocks WebFetch, webReader (MCP), and WebSearch tool calls.
+ * WebFetch/webReader redirect to fetch_and_index.
+ * WebSearch redirects to execute with curl/ddg for reliable results.
  */
 
 'use strict';
@@ -21,10 +22,36 @@ try {
   const input = JSON.parse(raw);
   const toolName = input.tool_name ?? '';
 
-  const BLOCKED = ['WebFetch', 'webReader', 'mcp__web_reader__webReader'];
+  const BLOCKED = ['WebFetch', 'webReader', 'mcp__web_reader__webReader', 'WebSearch'];
   if (!BLOCKED.includes(toolName)) process.exit(0);
 
-  // Extract URL from tool input
+  const isWebSearch = toolName === 'WebSearch';
+
+  if (isWebSearch) {
+    const query = input.tool_input?.query ?? input.tool_input?.args?.query ?? '';
+    console.error(`[web-fetch-guard] Blocked WebSearch for: ${query || '(no query)'}`);
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason:
+          `Do NOT use WebSearch — it's US-only and unreliable (often returns 0 results).\n` +
+          `Use execute with curl/ddg instead:\n` +
+          `\`\`\`\nexecute({\n` +
+          `  language: "javascript",\n` +
+          `  code: \`\n` +
+          `const res = await fetch('https://api.duckduckgo.com/?q=${encodeURIComponent('${query}')}&format=json');\n` +
+          `const data = await res.json();\n` +
+          `// Process data — console.log() only the answer\n` +
+          `\`\n` +
+          `})\n\`\`\`\n` +
+          `Or use batch_execute with curl/lynx for search results.`
+      }
+    }));
+    process.exit(0);
+  }
+
+  // WebFetch/webReader handling
   const url = input.tool_input?.url ?? input.tool_input?.input?.url ?? '';
 
   console.error(`[web-fetch-guard] Blocked ${toolName} on: ${url || '(no url)'}`);


### PR DESCRIPTION
## Summary
- web-fetch-guard now also blocks `WebSearch` tool calls
- WebSearch is US-only and unreliable (often returns 0 results)
- Redirects to `execute` with DuckDuckGo API or `batch_execute` with curl

## Test plan
- [x] WebSearch blocked with redirect guidance
- [x] WebFetch still blocked with fetch_and_index redirect
- [x] Read passes through (not this hook's concern)