### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Sandboxed code execution + FTS5 knowledge base. 3 tools: execute, batch_execute, search.",
   "mcpServers": {
     "context-mode": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "context-mode",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
-  "description": "Sandboxed code execution + FTS5 knowledge base. 3 tools: execute, batch_execute, search.",
+  "description": "Sandboxed code execution + FTS5 knowledge base. 4 MCP tools, 2 auto-enforcing hooks.",
   "author": "Kian Woon",
   "license": "Elastic-2.0",
   "keywords": [


### PR DESCRIPTION
Version bump to force plugin cache refresh. Includes fetch_and_index tool + web-fetch-guard with WebSearch blocking.