### PR TITLE
docs: add OpenSSF Scorecard security badge

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "context-mode",
   "version": "2.1.0",
-  "description": "Sandboxed code execution + FTS5 knowledge base. 3 tools: execute, batch_execute, search.",
+  "description": "Sandboxed code execution + FTS5 knowledge base. 4 tools: execute, batch_execute, search, fetch_and_index.",
   "mcpServers": {
     "context-mode": {
       "command": "node",

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ src/truncate.ts  — Output truncation
 hooks/           — PreToolUse guards (auto-enforce usage patterns)
 ```
 
+## Data lifecycle
+
+No user intervention needed — the plugin self-manages:
+
+| Mechanism | When | What |
+|-----------|------|------|
+| **Per-session DB** | On start | Each session gets its own temp SQLite DB (`context-mode-{pid}.db`). No cross-session accumulation. |
+| **Source dedup** | On index | Re-indexing the same source/label atomically replaces old content — prevents stale build-fix-build buildup. |
+| **TTL eviction** | On index | Entries older than 60 minutes are evicted before each new insert. |
+| **Session cleanup** | On exit | DB files + WAL/SHM are deleted when the process exits. |
+| **Orphan sweep** | On start | Stale DBs from dead PIDs or orphaned sessions (untouched >4hrs) are cleaned up at launch. |
+
+Result: the knowledge base stays lean automatically. No config, no cron, no manual cleanup.
+
 ## What's not here (by design)
 
 No adapters, no session DB, no CLI, no analytics. PreToolUse hooks auto-enforce best practices.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License](https://img.shields.io/badge/license-Elastic--2.0-green)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 [![CI](https://github.com/kianwoon/context-mode/actions/workflows/ci.yml/badge.svg)](https://github.com/kianwoon/context-mode/actions/workflows/ci.yml)
+[![Security](https://img.shields.io/badge/security-OpenSSF%20Scorecard-brightgreen)](https://securityscorecard.dev/#/github.com/kianwoon/context-mode)
 
 Sandboxed code execution + FTS5 knowledge base for Claude Code. 4 MCP tools, 2 auto-enforcing hooks.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@
 /**
  * context-mode v2 — Lean MCP server
  *
- * Three tools: execute, batch_execute, search.
- * No hooks, no adapters, no session DB, no analytics.
+ * Four tools: execute, batch_execute, search, fetch_and_index.
+ * Two auto-enforcing hooks: log-read-guard, web-fetch-guard.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";


### PR DESCRIPTION
Adds OpenSSF Scorecard badge to README.md alongside existing badges (version, license, Node, CI).

The badge links to [securityscorecard.dev](https://securityscorecard.dev/#/github.com/kianwoon/context-mode) showing the project's security posture.