### PR TITLE
feat: add Bash output guard hook

### DIFF
--- a/hooks/bash-output-guard.cjs
+++ b/hooks/bash-output-guard.cjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse Guard: Block high-output Bash commands
+ *
+ * Matcher: Bash
+ * Trigger: PreToolUse
+ * Latency: ~2ms (single JSON parse + regex check)
+ *
+ * Blocks Bash commands that produce large output:
+ *   - git log (without --oneline or -n limit)
+ *   - git diff (without file path or stat flag)
+ *   - find (broad searches)
+ *   - cat/head/tail on large files
+ *
+ * Redirects to execute() or batch_execute() instead.
+ */
+
+'use strict';
+
+try {
+  const fs = require('fs');
+
+  const raw = fs.readFileSync('/dev/stdin', 'utf8').trim();
+  if (!raw) process.exit(0);
+
+  const input = JSON.parse(raw);
+  const toolName = input.tool_name ?? '';
+  if (toolName !== 'Bash') process.exit(0);
+
+  const command = (input.tool_input?.command ?? '').trim();
+
+  // Patterns that produce large output
+  // git log without --oneline or -n<N> limit
+  const isGitLog = /^git\s+log\b/.test(command) &&
+    !/--oneline/.test(command) &&
+    !/-n\s*\d/.test(command) &&
+    !/--max-count/.test(command);
+
+  // git diff without --stat or file path (full diff dump)
+  const isGitDiff = /^git\s+diff\b/.test(command) &&
+    !/--stat/.test(command) &&
+    !/--name-only/.test(command) &&
+    !/--name-status/.test(command) &&
+    command.split(/\s+/).length <= 3; // bare "git diff" or "git diff HEAD"
+
+  // Broad find commands
+  const isBroadFind = /^find\s+[^|]*\s(-name|-type|-path)\s/.test(command) &&
+    !/head/.test(command) &&
+    !/-maxdepth\s+[12]\b/.test(command);
+
+  if (!isGitLog && !isGitDiff && !isBroadFind) process.exit(0);
+
+  let blockedCmd, suggestion;
+
+  if (isGitLog) {
+    blockedCmd = 'git log';
+    suggestion =
+      `Use execute() instead to process git log output:\n` +
+      `\`\`\`\nexecute({\n` +
+      `  language: "shell",\n` +
+      `  code: \`git log --oneline -20\`\n` +
+      `})\n\`\`\`\n` +
+      `Or batch_execute() for multi-command research.\n` +
+      `If you must use Bash, add --oneline or -n<N> to limit output.`;
+  } else if (isGitDiff) {
+    blockedCmd = 'git diff';
+    suggestion =
+      `Use execute() instead:\n` +
+      `\`\`\`\nexecute({\n` +
+      `  language: "shell",\n` +
+      `  code: \`git diff --stat\`\n` +
+      `})\n\`\`\`\n` +
+      `Or batch_execute() to run and index results.\n` +
+      `If you must use Bash, add --stat or --name-only to limit output.`;
+  } else {
+    blockedCmd = 'find';
+    suggestion =
+      `Use execute() or batch_execute() instead:\n` +
+      `\`\`\`\nexecute({\n` +
+      `  language: "shell",\n` +
+      `  code: \`find . -name "*.js" | head -20\`\n` +
+      `})\n\`\`\`\n` +
+      `Or use the Glob tool for file pattern matching.`;
+  }
+
+  console.error(`[bash-output-guard] Blocked ${blockedCmd}: ${command.slice(0, 80)}`);
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason:
+        `Do NOT run bare \`${blockedCmd}\` in Bash — raw output floods context window.\n` +
+        suggestion
+    }
+  }));
+  process.exit(0);
+} catch {
+  process.exit(0);
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Context-mode PreToolUse guards — blocks Read on data-heavy files (.log, .csv, .xml, .sql, .json >100KB) and WebFetch/webReader to conserve context window",
+  "description": "Context-mode PreToolUse guards — blocks Read on data-heavy files, WebFetch/webReader, and high-output Bash commands (bare git log/diff, broad find) to conserve context window",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,15 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/log-read-guard.cjs"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/bash-output-guard.cjs"
           }
         ]
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,6 +264,17 @@ const turndown = new TurndownService({
   codeBlockStyle: "fenced",
 });
 
+/** Detect pages that return RSC/SPA payloads instead of renderable HTML. */
+function isUnparseable(html: string): boolean {
+  // Next.js RSC streaming: self.__next_f.push([...])
+  if (html.includes("self.__next_f.push")) return true;
+  // High density of JS chunk references with minimal HTML structure
+  const chunkRefs = (html.match(/static\/chunks\/[\w-]+\.js/g) || []).length;
+  const htmlTags = (html.match(/<\/?(?:div|p|h[1-6]|ul|ol|li|table|section|article|main|header|footer)\b/g) || []).length;
+  if (chunkRefs > 10 && htmlTags < 5) return true;
+  return false;
+}
+
 server.registerTool(
   "fetch_and_index",
   {
@@ -297,6 +308,17 @@ server.registerTool(
         html = await res.text();
       } finally {
         clearTimeout(timer);
+      }
+
+      // Detect unparseable formats (RSC, SPA shells, etc.)
+      if (isUnparseable(html)) {
+        return textResult(
+          `fetch_and_index: Page returned an unparseable format (RSC/SPA payload). ` +
+          `The HTML-to-markdown converter cannot process this content. ` +
+          `Source the content from an alternative URL or format ` +
+          `(e.g., GitHub releases, API endpoint, raw markdown, cached/archive version).\n\nURL: ${url}`,
+          true,
+        );
       }
 
       // Extract title from raw HTML for section inventory


### PR DESCRIPTION
## Summary
- Add `bash-output-guard.cjs` PreToolUse hook that blocks high-output Bash commands
- Intercepts bare `git log`, `git diff`, and broad `find` commands
- Redirects to `execute()`/`batch_execute()` with bounded alternatives
- Registered in `hooks.json` alongside existing Read and WebFetch guards

## Test plan
- [ ] Verify `git log` (bare) is blocked with redirect guidance
- [ ] Verify `git log --oneline` passes through
- [ ] Verify `git log -n 5` passes through
- [ ] Verify `git diff` (bare) is blocked
- [ ] Verify `git diff --stat` passes through
- [ ] Verify broad `find` is blocked, scoped `find` passes