### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Sandboxed code execution + FTS5 knowledge base. 4 tools: execute, batch_execute, search, fetch_and_index.",
   "mcpServers": {
     "context-mode": {


### PR DESCRIPTION
Bump plugin version so reinstall picks up the bash-output-guard hook.