### PR TITLE
fix: block git diff with file paths in bash-output-guard

### DIFF
--- a/hooks/bash-output-guard.cjs
+++ b/hooks/bash-output-guard.cjs
@@ -41,12 +41,11 @@ try {
     !/-n\s*\d/.test(command) &&
     !/--max-count/.test(command);
 
-  // git diff without --stat, --name-only, or a file path
+  // git diff without --stat, --name-only, or --name-status
   const isGitDiff = /^git\s+diff\b/.test(command) &&
     !/--stat/.test(command) &&
     !/--name-only/.test(command) &&
-    !/--name-status/.test(command) &&
-    command.split(/\s+/).length <= 3;
+    !/--name-status/.test(command);
 
   // git show without --stat or --name-only (full diff dump)
   const isGitShow = /^git\s+show\b/.test(command) &&


### PR DESCRIPTION
## Summary
- Removed the `command.split(/\s+/).length <= 3` check that allowed `git diff main -- path/to/file` to bypass the guard
- All `git diff` commands without `--stat`/`--name-only`/`--name-status` are now blocked regardless of arguments

## Problem
The guard assumed scoping `git diff` to a file path bounds output. This was false — diffs on changed files can still produce 35+ lines that flood context.

## Test plan
- [ ] Verify `git diff` (bare) is blocked
- [ ] Verify `git diff main -- path/to/file` is now also blocked
- [ ] Verify `git diff --stat` still passes through
- [ ] Verify `git diff --name-only` still passes through