### PR TITLE
docs: mention hooks enforce context-mode rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Raw tool output floods your context window. Use context-mode MCP tools to keep raw data in the sandbox.
 
+**Hooks enforce this.** Bare `git log/diff`, `Read` on data files, and `WebFetch`/`webReader` are **auto-blocked** — don't fight the hooks, use the tools below.
+
 ## Think in Code — MANDATORY
 
 When you need to analyze, count, filter, compare, search, parse, transform, or process data: **write code** that does the work via `execute(language, code)` and `console.log()` only the answer. Do NOT read raw data into context to process mentally. Your role is to PROGRAM the analysis, not to COMPUTE it. Write robust, pure JavaScript — no npm dependencies, only Node.js built-ins (`fs`, `path`, `child_process`). Always use `try/catch`, handle `null`/`undefined`, and ensure compatibility with both Node.js and Bun. One script replaces ten tool calls and saves 100x context.


### PR DESCRIPTION
New users need to know blocked commands are enforced by hooks, not just suggestions.