### PR TITLE
fix: correct version mismatch in package.json and marketplace description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "context-mode",
-      "description": "Sandboxed code execution + FTS5 knowledge base. 3 MCP tools: execute, batch_execute, search. Zero hooks, zero build step.",
+      "description": "Sandboxed code execution + FTS5 knowledge base. 4 MCP tools: execute, batch_execute, search, fetch_and_index. Context-preserving hooks block raw HTML and high-output bash.",
       "category": "development",
       "source": "./"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "description": "Sandboxed code execution + FTS5 knowledge base. 4 MCP tools, 2 auto-enforcing hooks.",
   "author": "Kian Woon",


### PR DESCRIPTION
## Summary

- **package.json version**: 2.1.0 → 2.2.0 (fixes cache path mismatch)
- **marketplace.json**: corrected description to reflect actual 4-tool feature set and hook presence

## Root cause

The version in `package.json` (2.1.0) didn't match `plugin.json` (2.2.0). Claude Code uses `package.json` version to construct the plugin cache path (`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`), causing:

```
Plugin directory does not exist: .../context-mode/2.1.0
```

when the installer had recorded `2.2.0` in `installed_plugins.json`.

## Test plan

- [ ] `npm run build` completes without errors
- [ ] `claude plugin marketplace add <path>` + `install` succeeds
- [ ] All 4 MCP tools (execute, batch_execute, search, fetch_and_index) respond correctly
- [ ] Hooks fire without "directory does not exist" errors