### PR TITLE
fix: shift token-saving from PostToolUse to PreToolUse guards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,15 @@ No test framework is configured. The `better-sqlite3` dependency is externalized
 
 ## Architecture
 
-This is a Claude Code plugin (v2.2.0) that provides 4 MCP tools and 3 auto-enforcing PreToolUse hooks. The goal: keep raw tool output out of Claude's context window.
+This is a Claude Code plugin (v2.2.0) that provides 4 MCP tools and 4 auto-enforcing hooks. The goal: keep raw tool output out of Claude's context window.
+
+### Token-Saving Strategy
+
+| Layer | Mechanism | What it does |
+|---|---|---|
+| **Block** | PreToolUse `permissionDecision: "deny"` | Prevents known-dangerous patterns (bare git log, git diff, Read on data files, WebFetch) from executing |
+| **Guide** | PreToolUse `additionalContext` (once/session) | Advises on sandbox alternatives for non-blocked Bash/Read usage |
+| **Index** | PostToolUse `updatedMCPToolOutput` | Replaces large MCP tool output with compact FTS5 search instructions |
 
 ### MCP Server (`src/index.ts`)
 
@@ -43,12 +51,19 @@ Runs code via child process. Detects available runtimes at startup.
 
 ### Hooks (`hooks/`)
 
-Three PreToolUse guards defined in `hooks/hooks.json`:
-- **bash-output-guard.cjs** — blocks bare `git log`, `git diff`, `git show`, `git blame`, `git reflog`, `git stash list`, `git branch -a`, broad `find`
-- **log-read-guard.cjs** — blocks `Read` on data-heavy files (.log, .csv, .xml, .sql, .json >100KB)
-- **web-fetch-guard.cjs** — blocks `WebFetch`, `webReader`, `WebSearch`
+Four hooks defined in `hooks/hooks.json`:
 
-All hooks read stdin as JSON, check the tool command against regex patterns, and output a `permissionDecision: "deny"` with a redirect suggestion. They must stay under 50ms — no directory scans, no sync I/O on hot paths.
+**PreToolUse (3 hooks) — prevent bad patterns before execution:**
+- **bash-output-guard.cjs** — blocks bare `git log`, `git diff`, `git show`, `git blame`, `git reflog`, `git stash list`, `git branch -a`, broad `find`. Also shows one-time guidance for safe Bash commands.
+- **log-read-guard.cjs** — blocks `Read` on data-heavy files (.log, .csv, .xml, .sql, .json >100KB). Also shows one-time guidance for safe Reads.
+- **web-fetch-guard.cjs** — blocks `WebFetch`, `webReader`, `mcp__web_reader__webReader` (raw HTML floods context)
+
+**PostToolUse (1 hook) — safety net for MCP tools:**
+- **posttooluse-indexer.cjs** — indexes unexpectedly large MCP tool output (>5KB) into FTS5 and replaces output with search instructions via `updatedMCPToolOutput`
+
+**Guidance throttle:** PreToolUse hooks use `$TMPDIR/context-mode-guidance-{ppid}/{bash|read}` marker files with `O_CREAT | O_EXCL` to show guidance only once per session.
+
+All hooks read stdin as JSON, check against regex patterns, and output either `permissionDecision: "deny"` (block) or `additionalContext` (guide once). They must stay under 50ms — no directory scans, no sync I/O on hot paths.
 
 ### Plugin Config (`.claude-plugin/plugin.json`)
 

--- a/hooks/bash-output-guard.cjs
+++ b/hooks/bash-output-guard.cjs
@@ -79,7 +79,26 @@ try {
     isGitLog || isGitDiff || isGitShow || isGitBlame ||
     isGitReflog || isGitStash || isGitBranchAll || isBroadFind;
 
-  if (!isBlocked) process.exit(0);
+  if (!isBlocked) {
+    // One-time guidance via additionalContext (shown once per session)
+    const guidanceDir = `/tmp/context-mode-guidance-${process.ppid}`;
+    const guidanceMarker = `${guidanceDir}/bash`;
+    try {
+      fs.mkdirSync(guidanceDir, { recursive: true });
+      const fd = fs.openSync(guidanceMarker, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
+      fs.closeSync(fd);
+      console.log(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          additionalContext:
+            "Use batch_execute for multi-command research. Use execute for data processing. Bash for git/mkdir/rm/mv/short commands only."
+        }
+      }));
+    } catch {
+      // Marker exists — already shown guidance this session, pass through
+    }
+    process.exit(0);
+  }
 
   // ─── Suggestions ───────────────────────────────────────────────────
   let blockedCmd, suggestion;

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,9 +1,27 @@
 {
-  "description": "Context-mode hooks — PreToolUse redirect for raw HTML + universal PostToolUse auto-indexer for large output",
+  "description": "Context-mode hooks — PreToolUse deny/redirect for high-output tools, PostToolUse FTS5 indexing for MCP tools",
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "WebFetch|webReader",
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/bash-output-guard.cjs"
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/log-read-guard.cjs"
+          }
+        ]
+      },
+      {
+        "matcher": "WebFetch|webReader|mcp__web_reader__webReader",
         "hooks": [
           {
             "type": "command",
@@ -14,7 +32,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|Read|WebSearch|mcp__.*",
+        "matcher": "mcp__plugin_context-mode_context-mode__ctx_execute|mcp__plugin_context-mode_context-mode__ctx_batch_execute|mcp__plugin_context-mode_context-mode__ctx_fetch_and_index",
         "hooks": [
           {
             "type": "command",

--- a/hooks/log-read-guard.cjs
+++ b/hooks/log-read-guard.cjs
@@ -36,7 +36,26 @@ try {
     } catch { return false; }
   })();
 
-  if (!isBlockedExt && !isLargeJson) process.exit(0);
+  if (!isBlockedExt && !isLargeJson) {
+    // One-time guidance via additionalContext (shown once per session)
+    const guidanceDir = `/tmp/context-mode-guidance-${process.ppid}`;
+    const guidanceMarker = `${guidanceDir}/read`;
+    try {
+      fs.mkdirSync(guidanceDir, { recursive: true });
+      const fd = fs.openSync(guidanceMarker, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
+      fs.closeSync(fd);
+      console.log(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          additionalContext:
+            "Read is correct for files you intend to Edit. For analysis/exploration, use execute(language, code) instead."
+        }
+      }));
+    } catch {
+      // Marker exists — already shown guidance this session
+    }
+    process.exit(0);
+  }
 
   const fileExt = filePath.split('.').pop().toUpperCase();
   const sizeHint = isLargeJson ? ' (large JSON)' : '';

--- a/hooks/posttooluse-indexer.cjs
+++ b/hooks/posttooluse-indexer.cjs
@@ -2,14 +2,13 @@
 /**
  * PostToolUse hook: Universal auto-indexer for large tool output.
  *
- * Intercepts ALL tool output after execution. If output exceeds a byte threshold,
+ * Intercepts MCP tool output after execution. If output exceeds a byte threshold,
  * indexes it into the shared FTS5 knowledge base and replaces the output with
  * a compact summary + search instructions.
  *
- * This replaces PreToolUse guards for Bash/Read — instead of guessing which
- * commands/files produce large output, we check the ACTUAL output size.
+ * NOTE: updatedMCPToolOutput only works for MCP tools (mcp__*).
+ * Built-in tools (Bash, Read, Grep) are handled by PreToolUse guards instead.
  *
- * Uses updatedMCPToolOutput to replace what Claude sees in context.
  * Shares the same SQLite DB as the MCP server via deterministic path.
  */
 
@@ -146,21 +145,12 @@ try {
   ].join('\n');
 
   // updatedMCPToolOutput only works for MCP tools (mcp__*)
-  // For built-in tools (Bash, Read, WebSearch), we just index silently
-  const isMCPTool = toolName.startsWith('mcp__');
-
-  if (isMCPTool) {
-    process.stdout.write(JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PostToolUse',
-        updatedMCPToolOutput: summary,
-      },
-    }));
-  } else {
-    // For built-in tools, just exit 0 — original output passes through unchanged
-    // Output is indexed but still goes into context (can't replace built-in tool output)
-    process.exit(0);
-  }
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      updatedMCPToolOutput: summary,
+    },
+  }));
 } catch {
   // On error, pass through unchanged
   process.exit(0);


### PR DESCRIPTION
## Summary
- Re-wire PreToolUse guards as primary token-saving mechanism (PostToolUse `updatedMCPToolOutput` only works for MCP tools, not built-in tools)
- Add one-time `additionalContext` guidance throttle to bash-output-guard and log-read-guard (once per session via `O_CREAT | O_EXCL` marker files)
- Remove dead built-in tool handling from posttooluse-indexer.cjs
- Restructure hooks.json: 3 PreToolUse matchers (Bash, Read, WebFetch) + 1 PostToolUse (MCP tools only)
- Update CLAUDE.md with 3-layer strategy table (block, guide, index)

## Test plan
- [ ] `git log` without flags → denied with redirect to execute
- [ ] `git status` → passes through with one-time guidance
- [ ] Read on .log file → denied
- [ ] Read on .ts file → passes through with one-time guidance
- [ ] `WebFetch` → denied with redirect to fetch_and_index
- [ ] Fresh install: `claude plugin marketplace add <path> && claude plugin install context-mode@context-mode --scope user`
- [ ] Verify all hook files are intact in installed plugin