### PR TITLE
fix: remove stale ctx_ prefix from PostToolUse matcher

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -32,7 +32,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__plugin_context-mode_context-mode__ctx_execute|mcp__plugin_context-mode_context-mode__ctx_batch_execute|mcp__plugin_context-mode_context-mode__ctx_fetch_and_index",
+        "matcher": "mcp__plugin_context-mode_context-mode__execute|mcp__plugin_context-mode_context-mode__batch_execute|mcp__plugin_context-mode_context-mode__fetch_and_index",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Fix PostToolUse matcher in hooks.json — tool names are `execute`/`batch_execute`/`fetch_and_index`, not `ctx_execute`/`ctx_batch_execute`/`ctx_fetch_and_index`
- The incorrect `ctx_` prefix caused the PostToolUse indexer to **never fire**, meaning large MCP tool output was never indexed or compressed

## Test plan
- [ ] Verify PostToolUse hook fires when using execute/batch_execute/fetch_and_index with large output (>5KB)
- [ ] Verify `updatedMCPToolOutput` replacement works — output replaced with FTS5 search instructions