### PR TITLE
feat: improve hook guard UX with warn-first strategy and guidance TTL

### DIFF
--- a/hooks/bash-output-guard.cjs
+++ b/hooks/bash-output-guard.cjs
@@ -6,8 +6,12 @@
  * Trigger: PreToolUse
  * Latency: ~2ms (single JSON parse + regex check)
  *
- * Blocks Bash commands that produce large/unbounded output:
- *   - git log (without --oneline or -n limit)
+ * Strategy: warn-first, block-second
+ *   - 1st violation: additionalContext (soft warning, tool still executes)
+ *   - 2nd+ violation: permissionDecision "deny" (hard block)
+ *
+ * Blocks:
+ *   - git log (without --oneline or -n limit or | head)
  *   - git diff (without --stat or file path)
  *   - git show (without --stat or --name-only)
  *   - git blame (always — line-by-line annotation)
@@ -16,7 +20,8 @@
  *   - git branch -a (all branches)
  *   - find (broad searches without head or maxdepth)
  *
- * Redirects to execute() or batch_execute() with bounded alternatives.
+ * Guidance throttle: one-time additionalContext shown once per session,
+ * re-fires after 5 minutes (GUIDANCE_TTL_MS).
  */
 
 'use strict';
@@ -33,164 +38,208 @@ try {
 
   const command = (input.tool_input?.command ?? '').trim();
 
-  // ─── Git Commands ───────────────────────────────────────────────
+  // ─── Session-scoped paths ─────────────────────────────────────
+  const sessionDir = '/tmp/context-mode-guidance-' + process.ppid;
+  const strikesFile = sessionDir + '/bash-strikes';
+  const guidanceMarker = sessionDir + '/bash';
 
-  // git log without --oneline or -n<N> limit
-  const isGitLog = /^git\s+log\b/.test(command) &&
+  // ─── Guidance TTL (5 minutes) ─────────────────────────────────
+  var GUIDANCE_TTL_MS = 5 * 60 * 1000;
+
+  // ─── Git Commands ─────────────────────────────────────────────
+
+  // Commands piped to head are bounded — allow them
+  var isPipedToHead = /\|\s*head\b/.test(command);
+
+  // git log without --oneline or -n<N> limit or | head
+  var isGitLog = /^git\s+log\b/.test(command) &&
     !/--oneline/.test(command) &&
     !/-n\s*\d/.test(command) &&
-    !/--max-count/.test(command);
+    !/--max-count/.test(command) &&
+    !isPipedToHead;
 
   // git diff without --stat, --name-only, or --name-status
-  const isGitDiff = /^git\s+diff\b/.test(command) &&
+  var isGitDiff = /^git\s+diff\b/.test(command) &&
     !/--stat/.test(command) &&
     !/--name-only/.test(command) &&
     !/--name-status/.test(command);
 
   // git show without --stat or --name-only (full diff dump)
-  const isGitShow = /^git\s+show\b/.test(command) &&
+  var isGitShow = /^git\s+show\b/.test(command) &&
     !/--stat/.test(command) &&
     !/--name-only/.test(command) &&
     !/--name-status/.test(command);
 
   // git blame — line-by-line annotation, always dangerous
-  const isGitBlame = /^git\s+blame\b/.test(command);
+  var isGitBlame = /^git\s+blame\b/.test(command);
 
-  // git reflog — unbounded history, always dangerous
-  const isGitReflog = /^git\s+reflog\b/.test(command);
+  // git reflog — unbounded history
+  var isGitReflog = /^git\s+reflog\b/.test(command);
 
-  // git stash list — can grow indefinitely with many stashes
-  const isGitStash = /^git\s+stash\s+(list|show|pop|apply)\b/.test(command) &&
-    !/-n\s*\d/.test(command) &&
-    !/--max-count/.test(command);
+  // git stash list — can grow indefinitely
+  var isGitStash = /^git\s+stash\s+list\b/.test(command);
 
-  // git branch -a (all remotes + locals) — can be very long
-  const isGitBranchAll = /^git\s+branch\b/.test(command) &&
-    /-a\b/.test(command);
+  // git branch -a — all branches
+  var isGitBranchAll = /^git\s+branch\b/.test(command) && /-a\b/.test(command);
 
-  // ─── Shell Commands ────────────────────────────────────────────────
+  // find without head or maxdepth — broad file searches
+  var isFind = /^(find|gfind)\s/.test(command) &&
+    !/\|\s*head\b/.test(command) &&
+    !/-maxdepth\b/.test(command);
 
-  // Broad find without head or maxdepth 1-2
-  const isBroadFind = /^find\s+[^|]*\s(-name|-type|-path)\s/.test(command) &&
-    !/head/.test(command) &&
-    !/-maxdepth\s+[12]\b/.test(command);
-
-  const isBlocked =
-    isGitLog || isGitDiff || isGitShow || isGitBlame ||
-    isGitReflog || isGitStash || isGitBranchAll || isBroadFind;
+  // ─── Check if any pattern matches ────────────────────────────
+  var isBlocked = isGitLog || isGitDiff || isGitShow || isGitBlame ||
+    isGitReflog || isGitStash || isGitBranchAll || isFind;
 
   if (!isBlocked) {
-    // One-time guidance via additionalContext (shown once per session)
-    const guidanceDir = `/tmp/context-mode-guidance-${process.ppid}`;
-    const guidanceMarker = `${guidanceDir}/bash`;
+    // One-time guidance with expiry
     try {
-      fs.mkdirSync(guidanceDir, { recursive: true });
-      const fd = fs.openSync(guidanceMarker, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
-      fs.closeSync(fd);
-      console.log(JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-          additionalContext:
-            "Bash is for git/mkdir/rm/mv/short commands only. For everything else:\n" +
-            "- Research: batch_execute({commands: [{label, command}], queries: ['search terms']})\n" +
-            "- Data: execute({language: 'shell', code: 'git log --oneline -20'}) or execute({language: 'javascript', code: '...'})\n" +
-            "- Web: fetch_and_index({url, queries: ['terms']}) instead of WebFetch"
+      fs.mkdirSync(sessionDir, { recursive: true });
+      var showGuidance = false;
+      try {
+        var stat = fs.statSync(guidanceMarker);
+        if (Date.now() - stat.mtimeMs > GUIDANCE_TTL_MS) {
+          fs.unlinkSync(guidanceMarker);
+          showGuidance = true;
         }
-      }));
-    } catch {
-      // Marker exists — already shown guidance this session, pass through
+      } catch (e) {
+        showGuidance = true;
+      }
+      if (showGuidance) {
+        var fd = fs.openSync(guidanceMarker, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
+        fs.closeSync(fd);
+        console.log(JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            additionalContext:
+              "Bash is for git/mkdir/rm/mv/short commands only. For everything else:\n" +
+              "- Research: batch_execute({commands: [{label, command}], queries: ['search terms']})\n" +
+              "- Data: execute({language: 'shell', code: 'git log --oneline -20'}) or execute({language: 'javascript', code: '...'})\n" +
+              "- Web: fetch_and_index({url, queries: ['terms']}) instead of WebFetch"
+          }
+        }));
+      }
+    } catch (e) {
+      // Marker exists and not expired — already shown guidance
     }
     process.exit(0);
   }
 
-  // ─── Suggestions ───────────────────────────────────────────────────
-  let blockedCmd, suggestion;
+  // ─── Build suggestion message ─────────────────────────────────
+  var BT = '\x60'; // backtick character
+  var blockedCmd, suggestion;
 
   if (isGitLog) {
     blockedCmd = 'git log';
     suggestion =
-      `Use execute() instead:\n` +
-      `\`\`\`\nexecute({\n` +
-      `  language: "shell",\n` +
-      `  code: \`git log --oneline -20\`\n` +
-      `})\n\`\`\`\n` +
-      `Or batch_execute() for multi-command research.`;
+      "Use execute() instead:\n" +
+      "```\nexecute({\n" +
+      "  language: \"shell\",\n" +
+      "  code: " + BT + "git log --oneline -20" + BT + "\n" +
+      "})\n```\n" +
+      "Or batch_execute() for multi-command research.";
   } else if (isGitDiff) {
     blockedCmd = 'git diff';
     suggestion =
-      `Use execute() instead:\n` +
-      `\`\`\`\nexecute({\n` +
-      `  language: "shell",\n` +
-      `  code: \`git diff --stat\`\n` +
-      `})\n\`\`\`\n` +
-      `Or batch_execute() to run and index results.`;
+      "Use execute() instead:\n" +
+      "```\nexecute({\n" +
+      "  language: \"shell\",\n" +
+      "  code: " + BT + "git diff --stat" + BT + "\n" +
+      "})\n```\n" +
+      "Or batch_execute() to run and index results.";
   } else if (isGitShow) {
     blockedCmd = 'git show';
     suggestion =
-      `Use execute() instead:\n` +
-      `\`\`\`\nexecute({\n` +
-      `  language: "shell",\n` +
-      `  code: \`git show --stat <SHA>\`\n` +
-      `})\n\`\`\`\n` +
-      `Add --stat or --name-only to limit output.`;
+      "Use execute() instead:\n" +
+      "```\nexecute({\n" +
+      "  language: \"shell\",\n" +
+      "  code: " + BT + "git show --stat <SHA>" + BT + "\n" +
+      "})\n```\n" +
+      "Add --stat or --name-only to limit output.";
   } else if (isGitBlame) {
     blockedCmd = 'git blame';
     suggestion =
-      `Use execute() instead with a scoped file:\n` +
-      `\`\`\`\nexecute({\n` +
-      `  language: "shell",\n` +
-      `  code: \`git blame --count src/utils.js\`\n` +
-      `})\n\`\`\`\n` +
-      `Or process the file directly with execute() and parse it there.`;
+      "Use execute() instead with a scoped file:\n" +
+      "```\nexecute({\n" +
+      "  language: \"shell\",\n" +
+      "  code: " + BT + "git blame --count src/utils.js" + BT + "\n" +
+      "})\n```\n" +
+      "Or process the file directly with execute() and parse it there.";
   } else if (isGitReflog) {
     blockedCmd = 'git reflog';
     suggestion =
-      `Use execute() instead with a limit:\n` +
-      `\`\`\`\nexecute({\n` +
-      `  language: "shell",\n` +
-      `  code: \`git reflog -20\`\n` +
-      `})\n\`\`\`\n` +
-      `Reflog is unbounded — always use -n<N> to limit entries.`;
+      "Use execute() instead with a limit:\n" +
+      "```\nexecute({\n" +
+      "  language: \"shell\",\n" +
+      "  code: " + BT + "git reflog -20" + BT + "\n" +
+      "})\n```\n" +
+      "Reflog is unbounded — always use -n<N> to limit entries.";
   } else if (isGitStash) {
     blockedCmd = 'git stash list';
     suggestion =
-      `Use execute() instead:\n` +
-      `\`\`\`\nexecute({\n` +
-      `  language: "shell",\n` +
-      `  code: \`git stash list | head -20\`\n` +
-      `})\n\`\`\`\n` +
-      `Or pipe through head to bound output.`;
+      "Use execute() instead:\n" +
+      "```\nexecute({\n" +
+      "  language: \"shell\",\n" +
+      "  code: " + BT + "git stash list | head -20" + BT + "\n" +
+      "})\n```\n" +
+      "Or pipe through head to bound output.";
   } else if (isGitBranchAll) {
     blockedCmd = 'git branch -a';
     suggestion =
-      `Use execute() instead:\n` +
-      `\`\`\`\nexecute({\n` +
-      `  language: "shell",\n` +
-      `  code: \`git branch -a | head -30\`\n` +
-      `})\n\`\`\`\n` +
-      `Or use batch_execute() to run and index results.`;
+      "Use execute() instead:\n" +
+      "```\nexecute({\n" +
+      "  language: \"shell\",\n" +
+      "  code: " + BT + "git branch -a | head -30" + BT + "\n" +
+      "})\n```\n" +
+      "Or use batch_execute() to run and index results.";
   } else {
     blockedCmd = 'find';
     suggestion =
-      `Use execute() instead:\n` +
-      `\`\`\`\nexecute({\n` +
-      `  language: "shell",\n` +
-      `  code: \`find . -name "*.js" | head -20\`\n` +
-      `})\n\`\`\`\n` +
-      `Or use the Glob tool for file pattern matching.`;
+      "Use execute() instead:\n" +
+      "```\nexecute({\n" +
+      "  language: \"shell\",\n" +
+      "  code: " + BT + "find . -name \"*.js\" | head -20" + BT + "\n" +
+      "})\n```\n" +
+      "Or use the Glob tool for file pattern matching.";
   }
 
-  console.error(`[bash-output-guard] Blocked ${blockedCmd}: ${command.slice(0, 80)}`);
+  // ─── Strike counter: warn first, block second ─────────────────
+  fs.mkdirSync(sessionDir, { recursive: true });
+  var strikes = 0;
+  try {
+    strikes = parseInt(fs.readFileSync(strikesFile, 'utf8'), 10) || 0;
+  } catch (e) {}
+
+  strikes++;
+  fs.writeFileSync(strikesFile, String(strikes));
+
+  if (strikes <= 1) {
+    // First offense: soft warning — tool still executes
+    console.error('[bash-output-guard] Strike ' + strikes + ' (warning): ' + blockedCmd + ': ' + command.slice(0, 80));
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext:
+          "Do NOT run bare " + BT + blockedCmd + BT + " in Bash — raw output floods context window.\n" +
+          suggestion +
+          "\n\nThis is a WARNING. Next violation will be BLOCKED."
+      }
+    }));
+    process.exit(0); // allow through this time
+  }
+
+  // Second+ offense: hard block
+  console.error('[bash-output-guard] Strike ' + strikes + ' (blocked): ' + blockedCmd + ': ' + command.slice(0, 80));
   console.log(JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
       permissionDecisionReason:
-        `Do NOT run bare \`${blockedCmd}\` in Bash — raw output floods context window.\n` +
+        "Do NOT run bare " + BT + blockedCmd + BT + " in Bash — raw output floods context window.\n" +
         suggestion
     }
   }));
   process.exit(0);
-} catch {
+} catch (e) {
   process.exit(0);
 }

--- a/hooks/log-read-guard.cjs
+++ b/hooks/log-read-guard.cjs
@@ -7,9 +7,7 @@
  * Latency: ~2ms (single JSON parse + string check)
  *
  * Blocks Read on: .log, .csv, .xml, .sql, .json >100KB
- *
- * Non-zero exit blocks the tool call.
- * stdout JSON is shown to Claude as guidance.
+ * Guidance: one-time additionalContext, re-fires after 5 minutes.
  */
 
 'use strict';
@@ -24,6 +22,13 @@ try {
   const input = JSON.parse(raw);
   const filePath = input.tool_input?.file_path ?? '';
 
+  // ─── Session-scoped paths ─────────────────────────────────────
+  const sessionDir = `/tmp/context-mode-guidance-${process.ppid}`;
+  const guidanceMarker = `${sessionDir}/read`;
+
+  // ─── Guidance TTL (5 minutes) ─────────────────────────────────
+  const GUIDANCE_TTL_MS = 5 * 60 * 1000;
+
   // Extensions to block
   const BLOCKED_EXTENSIONS = ['.log', '.csv', '.xml', '.sql'];
   const ext = filePath.toLowerCase();
@@ -37,25 +42,35 @@ try {
   })();
 
   if (!isBlockedExt && !isLargeJson) {
-    // One-time guidance via additionalContext (shown once per session)
-    const guidanceDir = `/tmp/context-mode-guidance-${process.ppid}`;
-    const guidanceMarker = `${guidanceDir}/read`;
+    // Guidance with expiry: show once, re-fire after GUIDANCE_TTL_MS
     try {
-      fs.mkdirSync(guidanceDir, { recursive: true });
-      const fd = fs.openSync(guidanceMarker, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
-      fs.closeSync(fd);
-      console.log(JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-          additionalContext:
-            "Read is ONLY for files you intend to Edit. For analysis/exploration:\n" +
-            "- execute({language: 'javascript', code: 'const data = JSON.parse(fs.readFileSync(path)); console.log(Object.keys(data))'})\n" +
-            "- execute({language: 'shell', code: 'head -50 file.log | grep ERROR'})\n" +
-            "- batch_execute({commands: [{label:'file', command:'cat file.csv | head -20'}], queries: ['summary']})"
+      fs.mkdirSync(sessionDir, { recursive: true });
+      let showGuidance = false;
+      try {
+        const stat = fs.statSync(guidanceMarker);
+        if (Date.now() - stat.mtimeMs > GUIDANCE_TTL_MS) {
+          fs.unlinkSync(guidanceMarker);
+          showGuidance = true;
         }
-      }));
+      } catch {
+        showGuidance = true;
+      }
+      if (showGuidance) {
+        const fd = fs.openSync(guidanceMarker, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
+        fs.closeSync(fd);
+        console.log(JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            additionalContext:
+              "Read is ONLY for files you intend to Edit. For analysis/exploration:\n" +
+              "- execute({language: 'javascript', code: 'const data = JSON.parse(fs.readFileSync(path)); console.log(Object.keys(data))'})\n" +
+              "- execute({language: 'shell', code: 'head -50 file.log | grep ERROR'})\n" +
+              "- batch_execute({commands: [{label:'file', command:'cat file.csv | head -20'}], queries: ['summary']})"
+          }
+        }));
+      }
     } catch {
-      // Marker exists — already shown guidance this session
+      // Marker exists and not expired — already shown guidance
     }
     process.exit(0);
   }
@@ -71,16 +86,16 @@ try {
       permissionDecisionReason:
         `Do NOT use Read on ${fileExt}${sizeHint} files — raw ${fileExt} output floods context window.\n` +
         `Use execute instead:\n` +
-        `\`\`\`\nexecute({\n` +
+        "```\nexecute({\n" +
         `  language: "javascript",\n` +
-        `  code: \`\n` +
-        `const fs = require('fs');\n` +
+        "  code: `\n" +
+        "const fs = require('fs');\n" +
         `const data = JSON.parse(fs.readFileSync('${filePath}', 'utf8'));\n` +
-        `// Process, filter, aggregate — console.log() only the answer\n` +
-        `\`\n` +
-        `})\n\`\`\`\n` +
-        `Or use batch_execute for shell commands.\n` +
-        `Read tool is ONLY for files you intend to Edit.`
+        "// Process, filter, aggregate — console.log() only the answer\n" +
+        "`\n" +
+        "})\n```\n" +
+        "Or use batch_execute for shell commands.\n" +
+        "Read tool is ONLY for files you intend to Edit."
     }
   }));
   process.exit(0); // Exit 0 with JSON = deny


### PR DESCRIPTION
## Summary
- **Warn-first, block-second strategy** for `bash-output-guard` — first violation gives a soft warning (tool still executes), second+ hard blocks. Less frustrating than immediate deny.
- **Strike counter** via marker file persists across turns so the guard remembers prior violations.
- **Guidance TTL (5 min)** for both guards — re-shows helpful alternatives after 5 minutes instead of being a one-time hint that gets lost in long sessions.
- **Pipe detection** — allows safe patterns like `git log | head`, `find | head` instead of blanket-blocking.

## Test plan
- [x] Both hooks running in production this session — observed warn-first messages and TTL re-fires
- [x] `git stash pop` triggered the warning format (not hard deny on first offense)
- [x] Guidance re-appeared after 5 min gap in this session