### PR TITLE
chore: bump version to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "type": "module",
   "description": "Sandboxed code execution + FTS5 knowledge base. 4 MCP tools, 2 auto-enforcing hooks.",
   "author": "Kian Woon",


### PR DESCRIPTION
## Summary
Bump version to 2.5.0 for release.

Includes changes from #30 and #31.